### PR TITLE
Fix broken link to paper by Fabian Timm

### DIFF
--- a/_posts/2012-11-04-simple-accurate-eye-center-tracking-in-opencv.md
+++ b/_posts/2012-11-04-simple-accurate-eye-center-tracking-in-opencv.md
@@ -27,7 +27,7 @@ Here is a video he made of his algorithm in action:
 <iframe width="560" height="315" src="http://www.youtube.com/embed/aGmGyFLQAFM" frameborder="0" allowfullscreen="">
 </iframe>
 
-**Before continuing I recommend that you read [his paper](http://www.inb.uni-luebeck.de/publikationen/pdfs/TiBa11b.pdf).**
+**Before continuing I recommend that you read [his paper](https://www.inb.uni-luebeck.de/fileadmin/files/PUBPDFS/TiBa11b.pdf).**
 
 # Implementing the algorithm
 


### PR DESCRIPTION
The current link no longer works:
https://www.inb.uni-luebeck.de/publikationen/pdfs/TiBa11b.pdf
The new location would appear to be here:
https://www.inb.uni-luebeck.de/fileadmin/files/PUBPDFS/TiBa11b.pdf